### PR TITLE
Unmirror (No merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ TODO
 tox -- test/test_repository.py -s --no-cov
 
 # Testing
-Just a single test file: `tox -e unit -- test/test_repository.py -s`
+Just a single test file: `tox -e unit -- tests/test_repository.py -s`
 Lint and type check: `tox -e lint`
 Run all tox environments: `tox`
 
 # Debugging
 TODO: finish
-`tox -e unit -- test/test_repository.py -s --no-cov`
+`tox -e unit -- tests/test_repository.py -s --no-cov`

--- a/src/gordion/cache.py
+++ b/src/gordion/cache.py
@@ -33,5 +33,7 @@ class Cache:
     if not os.path.exists(local_path):
       args = ['git', 'clone', url, local_path]
       subprocess.check_call(args, stderr=subprocess.STDOUT)
+    else:
+      args = ['git', '-C', local_path, 'fetch']
 
     return local_path

--- a/src/gordion/cache.py
+++ b/src/gordion/cache.py
@@ -29,9 +29,9 @@ class Cache:
     host, username, repo_name = gordion.extract_repo_details(url)
     local_path = os.path.join(CACHE_DIR, "mirrors", host, username, repo_name)
 
-    # Clone if the mirror does not exist
+    # Clone if the mirror does not exist, otherwise fetch
     if not os.path.exists(local_path):
-      args = ['git', 'clone', '--mirror', url, local_path]
+      args = ['git', 'clone', url, local_path]
       subprocess.check_call(args, stderr=subprocess.STDOUT)
 
     return local_path

--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -34,7 +34,6 @@ class Repository:
 
       args = ['git', '-C', self.path, 'remote', 'set-url', 'origin', self.url]
       subprocess.check_call(args, stderr=subprocess.STDOUT)
-      return
 
     # TODO: Checkout the branch:tag
 

--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -27,8 +27,6 @@ class Repository:
       cache = gordion.Cache()
       mirror_path = cache.ensure_mirror(self.url)
 
-      # args = ['git', 'clone', '--dissociate', '--reference', mirror_path, self.path]
-      # args = ['git', 'clone', '--reference', mirror_path, self.url, self.path]
       args = ['git', 'clone', mirror_path, self.path]
       subprocess.check_call(args, stderr=subprocess.STDOUT)
 

--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -27,8 +27,14 @@ class Repository:
       cache = gordion.Cache()
       mirror_path = cache.ensure_mirror(self.url)
 
-      args = ['git', 'clone', '--reference', mirror_path, self.url, self.path]
+      # args = ['git', 'clone', '--dissociate', '--reference', mirror_path, self.path]
+      # args = ['git', 'clone', '--reference', mirror_path, self.url, self.path]
+      args = ['git', 'clone', mirror_path, self.path]
       subprocess.check_call(args, stderr=subprocess.STDOUT)
+
+      args = ['git', '-C', self.path, 'remote', 'set-url', 'origin', self.url]
+      subprocess.check_call(args, stderr=subprocess.STDOUT)
+      return
 
     # TODO: Checkout the branch:tag
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -48,22 +48,22 @@ class TestRepository(unittest.TestCase):
     args = ["git", "-C", path, "commit", "--allow-empty", "-m", "Empty commit for testing"]
     subprocess.check_call(args)
 
-    # # Verify update error. User needs to save the commits, or force the update.
-    # with self.assertRaises(gordion.UpdateActiveBranchAheadError) as context:
-    #   repo.update()
-    # expected = gordion.UpdateActiveBranchAheadError(path, 'develop', 'origin/develop', 1)
-    # self.assertEqual(str(context.exception), str(expected))
+    # Verify update error. User needs to save the commits, or force the update.
+    with self.assertRaises(gordion.UpdateActiveBranchAheadError) as context:
+      repo.update()
+    expected = gordion.UpdateActiveBranchAheadError(path, 'develop', 'origin/develop', 1)
+    self.assertEqual(str(context.exception), str(expected))
 
-    # # Create a new local branch
-    # args = ["git", "-C", path, "checkout", "-b", "test_branch"]
-    # subprocess.check_call(args, stderr=subprocess.STDOUT)
+    # Create a new local branch
+    args = ["git", "-C", path, "checkout", "-b", "test_branch"]
+    subprocess.check_call(args, stderr=subprocess.STDOUT)
 
-    # # Verify update scucceeds because no information is lost.
-    # repo.update()
+    # Verify update scucceeds because no information is lost.
+    repo.update()
 
-    # # Older commit same branch.
-    # tag = 'f68eccca87b05ca29c3a9ae0d71475f8f33115cd'
-    # repo = Repository(path, url, tag, branch)
-    # repo.update()
+    # Older commit same branch.
+    tag = 'f68eccca87b05ca29c3a9ae0d71475f8f33115cd'
+    repo = Repository(path, url, tag, branch)
+    repo.update()
 
     # TODO test remote is ahead.

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -61,9 +61,9 @@ class TestRepository(unittest.TestCase):
     # Verify update scucceeds because no information is lost.
     repo.update()
 
-    # Older commit same branch.
-    tag = 'f68eccca87b05ca29c3a9ae0d71475f8f33115cd'
-    repo = Repository(path, url, tag, branch)
-    repo.update()
+    # # Older commit same branch.
+    # tag = 'f68eccca87b05ca29c3a9ae0d71475f8f33115cd'
+    # repo = Repository(path, url, tag, branch)
+    # repo.update()
 
     # TODO test remote is ahead.

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -48,18 +48,18 @@ class TestRepository(unittest.TestCase):
     args = ["git", "-C", path, "commit", "--allow-empty", "-m", "Empty commit for testing"]
     subprocess.check_call(args)
 
-    # Verify update error. User needs to save the commits, or force the update.
-    with self.assertRaises(gordion.UpdateActiveBranchAheadError) as context:
-      repo.update()
-    expected = gordion.UpdateActiveBranchAheadError(path, 'develop', 'origin/develop', 1)
-    self.assertEqual(str(context.exception), str(expected))
+    # # Verify update error. User needs to save the commits, or force the update.
+    # with self.assertRaises(gordion.UpdateActiveBranchAheadError) as context:
+    #   repo.update()
+    # expected = gordion.UpdateActiveBranchAheadError(path, 'develop', 'origin/develop', 1)
+    # self.assertEqual(str(context.exception), str(expected))
 
-    # Create a new local branch
-    args = ["git", "-C", path, "checkout", "-b", "test_branch"]
-    subprocess.check_call(args, stderr=subprocess.STDOUT)
+    # # Create a new local branch
+    # args = ["git", "-C", path, "checkout", "-b", "test_branch"]
+    # subprocess.check_call(args, stderr=subprocess.STDOUT)
 
-    # Verify update scucceeds because no information is lost.
-    repo.update()
+    # # Verify update scucceeds because no information is lost.
+    # repo.update()
 
     # # Older commit same branch.
     # tag = 'f68eccca87b05ca29c3a9ae0d71475f8f33115cd'


### PR DESCRIPTION

Clone without mirror to the cache, and clone locally from there. Then fetch. This is faster, but I'm concerned it won't be later because if you have to fastforward a long git history I have a feeling that's where the time will go, since I'm never pulling in the cache repo. 

Basically I don't think this would be better, but keeping around for now.