### PR TITLE
Do not change repository branch if commit is constant

### DIFF
--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -4,6 +4,7 @@ import git
 import gordion
 from typing import List
 import shutil
+import traceback
 
 
 class Repository:
@@ -94,6 +95,23 @@ class Repository:
     root = self._root()
     self._check_duplicate_repo_tag(tag, root)
 
+    # If the commit does not change, we are done. Allow user to manually checkout a HEAD or
+    # different branch name and still satisfy the update.
+    if self.handle.head.commit.hexsha != commit.hexsha:
+      self._update_moving_commit(commit, branch_name, force)
+
+    self.yeditor.reload()
+    self._update_children(branch_name, force)
+
+    # Cleanup detached repositories.
+    if self is root:
+      self._clean_detached_repos(force)
+
+  def _update_moving_commit(self, commit: git.Commit, branch_name: str,
+                            force: bool = False) -> None:
+    """
+    The internal version of the update() method. Called only if the commit moves.
+    """
     # Verify that we don't have an unsaved HEAD that would be lost by the update.
     if self.handle.head.is_detached:
       self._verify_head_wont_be_lost(commit)
@@ -105,18 +123,16 @@ class Repository:
 
     # Check if a branch HAS NOT been specified.
     if not branch_name:
-      # If we are already on this commit, then we are done. Don't add extra checks and don't
-      # checkout in detached HEAD state.
-      if self.handle.head.commit.hexsha != commit.hexsha:
-        # Checkout the target commit in a detached HEAD state as long as it is not dangling.
-        self._check_dangling_commit(commit)
-        self.handle.git.checkout(commit)
+      # Checkout the target commit in a detached HEAD state as long as it is not dangling.
+      self._check_dangling_commit(commit)
+      self.handle.git.checkout(commit)
 
     # A branch HAS been specified
     else:
       # Check if a local branch by the target name has the target commit.
       if Repository._does_local_branch_have_commit(self.handle, branch_name, commit):
         local_branch = self.handle.branches[branch_name]
+
         # Check if target commit is HEAD of local branch.
         if commit.hexsha == local_branch.commit.hexsha:
           local_branch.checkout()
@@ -140,8 +156,9 @@ class Repository:
           local_branch.checkout()
           self.handle.head.reset(commit=commit, index=True, working_tree=True)
 
-      # Tag is not on a local branch
+      # Tag is not on the specified local branch.
       else:
+
         self.fetch_once()
 
         # Check if a remote branch by the target name has the target commit.
@@ -173,19 +190,9 @@ class Repository:
         # We could not find the commit on a local or remote branch by the designated name, so just
         # checkout the commit in a detached head state.
         else:
-          # If we are already on this commit, then we are done. Don't add extra checks and don't
-          # checkout in detached HEAD state.
-          if self.handle.head.commit.hexsha != commit.hexsha:
-            # Checkout the target commit in a detached HEAD state as long as it is not dangling.
-            self._check_dangling_commit(commit)
-            self.handle.git.checkout(commit)
-
-    self.yeditor.reload()
-    self._update_children(branch_name, force)
-
-    # Cleanup detached repositories.
-    if self is root:
-      self._clean_detached_repos(force)
+          # Checkout the target commit in a detached HEAD state as long as it is not dangling.
+          self._check_dangling_commit(commit)
+          self.handle.git.checkout(commit)
 
   def _list_child_repository_paths(self) -> List[str]:
     paths = []
@@ -449,6 +456,7 @@ class Repository:
     Fetches only once for the lifetime of this Repository object.
     """
     if not self.fetched:
+      print("fetch once")
       # NOTE: The `--prune` option deletes local remote-tracking branches that no longer have
       # corresponding branches on the remote repository. When a child repository deletes a remote
       # branch (e.g. a PR is merged), we want the parent repository to see that deletion. Assuming

--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -4,7 +4,6 @@ import git
 import gordion
 from typing import List
 import shutil
-import traceback
 
 
 class Repository:
@@ -456,7 +455,6 @@ class Repository:
     Fetches only once for the lifetime of this Repository object.
     """
     if not self.fetched:
-      print("fetch once")
       # NOTE: The `--prune` option deletes local remote-tracking branches that no longer have
       # corresponding branches on the remote repository. When a child repository deletes a remote
       # branch (e.g. a PR is merged), we want the parent repository to see that deletion. Assuming

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -25,7 +25,7 @@ def repo_a(repo_a_session):
   """
 
   # Set the object to a known commit on the test_single branch.
-  tag = '26968db5866b41339b9811c809818f44055c8153'
+  tag = 'a415fa52649601f17fccf6d17616281213b117b8'
   branch_name = 'test_single'
 
   # Set the target branch/commit
@@ -47,7 +47,7 @@ def test_verify_tag(repo_a):
   repo_a._verify_tag(repo_a.handle.head.commit.parents[0].hexsha)
 
   # Verify a tag that only exists on a different remote branch (test_single_1) in fact exists.
-  repo_a._verify_tag('f30a7cbe5592ef4521dad06203d5178e651ecd5b')
+  repo_a._verify_tag('05090461f38c8b725d89bf30a31c716383778b48')
 
   # Verify that an ill-formed commit will raise an error.
   with pytest.raises(git.BadName):
@@ -82,7 +82,7 @@ def test_does_local_branch_have_commit(repo_a):
       repo_a.handle, 'test_single_1', head_commit)
 
   # Verfiy commit on remote but not on local returns false.
-  future_commit = repo_a._verify_tag('a415fa52649601f17fccf6d17616281213b117b8')
+  future_commit = repo_a._verify_tag('04518b39225d45f69fc9a2f9f5c0dba1fe6a6227')
   assert not gordion.Repository._does_local_branch_have_commit(
       repo_a.handle, 'test_single', future_commit)
 
@@ -113,8 +113,9 @@ def test_update_nonactive_local_branch_commits_ahead(repo_a):
   repo_a.handle.branches['test_single'].checkout()
 
   # Verify update error. User needs to save the commits, or force the update.
+  # NOTE: the commit needs to move, so checkout HEAD~1
   with pytest.raises(gordion.UpdateLocalBranchAheadError) as context:
-    repo_a.update(repo_a.handle.head.commit.hexsha, "test_single_1")
+    repo_a.update(repo_a.handle.commit('HEAD~1').hexsha, "test_single_1")
   expected = gordion.UpdateLocalBranchAheadError(repo_a, 'test_single_1', 'origin/test_single_1', 1)
   assert str(context.value) == str(expected)
 
@@ -146,7 +147,7 @@ def test_does_remote_branch_have_commit(repo_a):
   """
 
   # Verify a commit is on remote branch but not local.
-  commit = repo_a._verify_tag('a415fa52649601f17fccf6d17616281213b117b8')
+  commit = repo_a._verify_tag('04518b39225d45f69fc9a2f9f5c0dba1fe6a6227')
   assert not gordion.Repository._does_local_branch_have_commit(repo_a.handle, 'test_single', commit)
   assert gordion.Repository._does_remote_branch_have_commit(repo_a.handle, 'test_single', commit)
 
@@ -166,10 +167,10 @@ def test_update_remote_branch_only(repo_a):
   Verifies that update will create a new local branch to track the remote branch if it does not
   exist yet AND the remote branch has the target commit.
   """
-  baseline_commit = repo_a.handle.head.commit.hexsha
-  repo_a.update(baseline_commit, "test_single_1")
+  new_commit = repo_a.handle.commit('HEAD~1').hexsha
+  repo_a.update(new_commit, "test_single_1")
   assert repo_a.handle.head.reference.name == "test_single_1"
-  assert repo_a.handle.head.commit.hexsha == baseline_commit
+  assert repo_a.handle.head.commit.hexsha == new_commit
 
 
 def test_update_local_fastforward(repo_a):
@@ -204,7 +205,7 @@ def test_branch_does_not_have_commit_but_commit_exists(repo_a):
   """
 
   # Choose a tag that exists on 'test_single_1' but not on test_single.
-  tag = 'f30a7cbe5592ef4521dad06203d5178e651ecd5b'
+  tag = '05090461f38c8b725d89bf30a31c716383778b48'
   repo_a.update(tag, "test_single")
   assert repo_a.handle.head.is_detached
   assert repo_a.handle.head.commit.hexsha == tag


### PR DESCRIPTION
If a commit is not changing, don't update the underlying repository branch. This allows a user to checkout a HEAD or different branch than the root branch, without a `gordion -u` moving it back as long as the commit is not changing. It also saves us from needing to call fetch in the semi-nominal workflow where a child repository does not have the same branch as the root repository. In this case, the previous behavior was to fetch the remote to see if it contains the root branch every time we update, which takes time and is annoying for a common behavior. Now, it can be expected that if a user calls `gordion -u` twice in a row, the second time will do nothing and be fast.