### PR TITLE
Use the default branch when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ tox -- test/test_repository.py -s --no-cov
 
 # Testing
 Just a single test file:
-  `tox -e unit -- tests/test_single.py -s`
-  `tox -e unit -- tests/test_diamond.py -s`
+  `tox -e unit -- tests/test_repository.py -s`
+  `tox -e unit -- tests/test_tree.py -s`
   `tox -e unit -- tests/test_app.py -s`
   `tox -e unit -- tests/test_cache.py -s`
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Just a single test file:
   `tox -e unit -- tests/test_single.py -s`
   `tox -e unit -- tests/test_diamond.py -s`
   `tox -e unit -- tests/test_app.py -s`
+  `tox -e unit -- tests/test_cache.py -s`
+
 
 Lint and type check: `tox -e lint`
 Run all tox environments: `tox`

--- a/src/gordion/cache.py
+++ b/src/gordion/cache.py
@@ -21,7 +21,7 @@ class Cache:
     shutil.rmtree(CACHE_DIR)
     os.makedirs(CACHE_DIR)
 
-  def ensure_mirror(self, url: str) -> str:
+  def ensure_mirror(self, url: str) -> tuple[str, str]:
     """
     Clones a mirror if it does not already exist. Returns the path and default branch name.
 

--- a/src/gordion/cache.py
+++ b/src/gordion/cache.py
@@ -2,8 +2,9 @@ import os
 import gordion
 import subprocess
 import shutil
+import git
 
-CACHE_DIR = os.path.join(os.environ['HOME'], '.gordion')
+CACHE_DIR = os.path.join(os.environ['HOME'], '.local', 'share', 'gordion')
 
 
 class Cache:
@@ -22,7 +23,7 @@ class Cache:
 
   def ensure_mirror(self, url: str) -> str:
     """
-    Clones a mirror if it does not already exist
+    Clones a mirror if it does not already exist. Returns the path and default branch name.
 
     """
 
@@ -34,4 +35,8 @@ class Cache:
       args = ['git', 'clone', '--mirror', url, local_path]
       subprocess.check_call(args, stderr=subprocess.STDOUT)
 
-    return local_path
+    # Get the default branch
+    mirror = git.Repo(local_path)
+    default_branch_name = mirror.active_branch.name
+
+    return local_path, default_branch_name

--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -90,25 +90,31 @@ class Repository:
 
     # A branch HAS been specified
     else:
-      # Check if a local branch by the target name has the target commit.
-      if Repository._does_local_branch_have_commit(self.handle, branch_name, commit):
-        self._checkout_local_branch_commit(branch_name, commit, force)
-
-      # Tag is not on the specified local branch.
-      else:
-
-        self._fetch_once()
-
-        # Check if a remote branch by the target name has the target commit.
-        if Repository._does_remote_branch_have_commit(self.handle, branch_name, commit):
-          self._checkout_remote_branch_commit(branch_name, commit, force)
-
+      if not self._try_checkout_branch_commit(branch_name, commit, force):
         # We could not find the commit on a local or remote branch by the designated name, so just
-        # checkout the commit in a detached head state.
-        else:
-          # Checkout the target commit in a detached HEAD state as long as it is not dangling.
-          self._check_dangling_commit(commit)
-          self.handle.git.checkout(commit)
+        # checkout the commit in a detached head state. Checkout the target commit in a detached
+        # HEAD state as long as it is not dangling.
+        self._check_dangling_commit(commit)
+        self.handle.git.checkout(commit)
+
+  def _try_checkout_branch_commit(self, branch_name: str, commit: git.Commit, force: bool) -> bool:
+    # Check if a local branch by the target name has the target commit.
+    if Repository._does_local_branch_have_commit(self.handle, branch_name, commit):
+      self._checkout_local_branch_commit(branch_name, commit, force)
+      # TODO make the function return
+      return True
+
+    # Tag is not on the specified local branch.
+    else:
+
+      self._fetch_once()
+
+      # Check if a remote branch by the target name has the target commit.
+      if Repository._does_remote_branch_have_commit(self.handle, branch_name, commit):
+        self._checkout_remote_branch_commit(branch_name, commit, force)
+        return True
+
+      return False
 
   def _checkout_local_branch_commit(self, branch_name: str, commit: git.Commit, force: bool):
     local_branch = self.handle.branches[branch_name]

--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -101,29 +101,7 @@ class Repository:
 
         # Check if a remote branch by the target name has the target commit.
         if Repository._does_remote_branch_have_commit(self.handle, branch_name, commit):
-
-          # Check if there is a local branch to match the remote branch.
-          local_branches = [branch.name for branch in self.handle.branches]
-
-          if branch_name in local_branches:
-            # Make sure the local branch is setup to track the expected remote branch.
-            local_branch = self.handle.branches[branch_name]
-            tracking_branch = self._verify_local_branch_has_correct_tracking_branch(local_branch)
-
-            # Make sure the local branch is not ahead of tracking branch, since we're moving the
-            # local HEAD, information would be lost.
-            if not force:
-              self._verify_local_commits_not_ahead(local_branch, tracking_branch)
-
-            # Good to go move the local branch HEAD to the target commit.
-            print(f"{self._relpath()}: checking out {local_branch.name}:{commit.hexsha}")
-            local_branch.checkout()
-            self.handle.head.reset(commit=commit, index=True, working_tree=True)
-
-          # There is no local branch yet, create it, and reset it to the target commit.
-          else:
-            self.handle.git.checkout('-b', branch_name, f'origin/{branch_name}')
-            self.handle.head.reset(commit=commit, index=True, working_tree=True)
+          self._checkout_remote_branch_commit(branch_name, commit, force)
 
         # We could not find the commit on a local or remote branch by the designated name, so just
         # checkout the commit in a detached head state.
@@ -156,6 +134,30 @@ class Repository:
       # Good to go move the local branch HEAD to the target commit.
       print(f"{self._relpath()}: checking out {local_branch.name}:{commit.hexsha}")
       local_branch.checkout()
+      self.handle.head.reset(commit=commit, index=True, working_tree=True)
+
+  def _checkout_remote_branch_commit(self, branch_name: str, commit: git.Commit, force: bool):
+    # Check if there is a local branch to match the remote branch.
+    local_branches = [branch.name for branch in self.handle.branches]
+
+    if branch_name in local_branches:
+      # Make sure the local branch is setup to track the expected remote branch.
+      local_branch = self.handle.branches[branch_name]
+      tracking_branch = self._verify_local_branch_has_correct_tracking_branch(local_branch)
+
+      # Make sure the local branch is not ahead of tracking branch, since we're moving the
+      # local HEAD, information would be lost.
+      if not force:
+        self._verify_local_commits_not_ahead(local_branch, tracking_branch)
+
+      # Good to go move the local branch HEAD to the target commit.
+      print(f"{self._relpath()}: checking out {local_branch.name}:{commit.hexsha}")
+      local_branch.checkout()
+      self.handle.head.reset(commit=commit, index=True, working_tree=True)
+
+    # There is no local branch yet, create it, and reset it to the target commit.
+    else:
+      self.handle.git.checkout('-b', branch_name, f'origin/{branch_name}')
       self.handle.head.reset(commit=commit, index=True, working_tree=True)
 
   def _check_dangling_commit(self, commit):

--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -66,12 +66,11 @@ class Repository:
     # If the commit does not change, we are done. Allow user to manually checkout a HEAD or
     # different branch name and still satisfy the update.
     if self.handle.head.commit.hexsha != commit.hexsha:
-      self._update_moving_commit(commit, branch_name, force)
+      self._checkout(commit, branch_name, force)
 
-  def _update_moving_commit(self, commit: git.Commit, branch_name: str,
-                            force: bool = False) -> None:
+  def _checkout(self, commit: git.Commit, branch_name: str, force: bool = False) -> None:
     """
-    The internal version of the update() method. Called only if the commit moves.
+    Checks out the specified commit and optional branch.
     """
     # Verify that we don't have an unsaved HEAD that would be lost by the update.
     if self.handle.head.is_detached:
@@ -85,7 +84,7 @@ class Repository:
     # Check if a branch HAS NOT been specified.
     if not branch_name:
       # Try the default branch.
-      if not self._try_checkout_branch_commit(self.default_branch_name, commit, force):
+      if not self._try_checkout(self.default_branch_name, commit, force):
         # Checkout the target commit in a detached HEAD state as long as it is not dangling.
         self._check_dangling_commit(commit)
         self.handle.git.checkout(commit)
@@ -93,17 +92,19 @@ class Repository:
     # A branch HAS been specified.
     else:
       # Try the specified branch.
-      if not self._try_checkout_branch_commit(branch_name, commit, force):
+      if not self._try_checkout(branch_name, commit, force):
         # Try the default branch.
-        if not self._try_checkout_branch_commit(self.default_branch_name, commit, force):
+        if not self._try_checkout(self.default_branch_name, commit, force):
           # Checkout the target commit in a detached HEAD state as long as it is not dangling.
           self._check_dangling_commit(commit)
           self.handle.git.checkout(commit)
 
-  def _try_checkout_branch_commit(self, branch_name: str, commit: git.Commit, force: bool) -> bool:
-    # Check if a local branch by the target name has the target commit.
-    if Repository._does_local_branch_have_commit(self.handle, branch_name, commit):
-      self._checkout_local_branch_commit(branch_name, commit, force)
+  def _try_checkout(self, branch_name: str, commit: git.Commit, force: bool) -> bool:
+    """
+    Attempts to checkout the commit on the specified branch, returns the success of the request.
+    """
+    # Try the local branch.
+    if self._try_checkout_local(branch_name, commit, force):
       return True
 
     # Tag is not on the specified local branch.
@@ -111,62 +112,80 @@ class Repository:
 
       self._fetch_once()
 
-      # Check if a remote branch by the target name has the target commit.
-      if Repository._does_remote_branch_have_commit(self.handle, branch_name, commit):
-        self._checkout_remote_branch_commit(branch_name, commit, force)
-        return True
+      # Try the remote branch
+      return self._try_checkout_remote(branch_name, commit, force)
 
-      return False
-
-  def _checkout_local_branch_commit(self, branch_name: str, commit: git.Commit, force: bool):
-    local_branch = self.handle.branches[branch_name]
+  def _try_checkout_local(self, branch_name: str, commit: git.Commit, force: bool) -> bool:
+    """
+    Attempts to checkout the commit on the specified LOCAL branch, returns the success of the
+    request.
+    """
 
     # Check if target commit is HEAD of local branch.
-    if commit == local_branch.commit:
-      local_branch.checkout()
-
-    # Target commit is in local branch history.
-    else:
-      # Need to fetch for this part of the logic.
-      self._fetch_once()
-
-      # Make sure the local branch is setup to track the expected remote branch.
+    if Repository._does_local_branch_have_commit(self.handle, branch_name, commit):
       local_branch = self.handle.branches[branch_name]
-      tracking_branch = self._verify_local_branch_has_correct_tracking_branch(local_branch)
 
-      # Make sure the local branch is not ahead of tracking branch, since we're moving the
-      # local HEAD, information would be lost.
-      if not force:
-        self._verify_local_commits_not_ahead(local_branch, tracking_branch)
+      if commit == local_branch.commit:
+        local_branch.checkout()
+        return True
 
-      # Good to go move the local branch HEAD to the target commit.
-      print(f"{self._relpath()}: checking out {local_branch.name}:{commit.hexsha}")
-      local_branch.checkout()
-      self.handle.head.reset(commit=commit, index=True, working_tree=True)
+      # Target commit is in local branch history.
+      else:
+        # Need to fetch for this part of the logic.
+        self._fetch_once()
 
-  def _checkout_remote_branch_commit(self, branch_name: str, commit: git.Commit, force: bool):
-    # Check if there is a local branch to match the remote branch.
-    local_branches = [branch.name for branch in self.handle.branches]
+        # Make sure the local branch is setup to track the expected remote branch.
+        local_branch = self.handle.branches[branch_name]
+        tracking_branch = self._verify_local_branch_has_correct_tracking_branch(local_branch)
 
-    if branch_name in local_branches:
-      # Make sure the local branch is setup to track the expected remote branch.
-      local_branch = self.handle.branches[branch_name]
-      tracking_branch = self._verify_local_branch_has_correct_tracking_branch(local_branch)
+        # Make sure the local branch is not ahead of tracking branch, since we're moving the
+        # local HEAD, information would be lost.
+        if not force:
+          self._verify_local_commits_not_ahead(local_branch, tracking_branch)
 
-      # Make sure the local branch is not ahead of tracking branch, since we're moving the
-      # local HEAD, information would be lost.
-      if not force:
-        self._verify_local_commits_not_ahead(local_branch, tracking_branch)
+        # Good to go move the local branch HEAD to the target commit.
+        print(f"{self._relpath()}: checking out {local_branch.name}:{commit.hexsha}")
+        local_branch.checkout()
+        self.handle.head.reset(commit=commit, index=True, working_tree=True)
+        return True
 
-      # Good to go move the local branch HEAD to the target commit.
-      print(f"{self._relpath()}: checking out {local_branch.name}:{commit.hexsha}")
-      local_branch.checkout()
-      self.handle.head.reset(commit=commit, index=True, working_tree=True)
-
-    # There is no local branch yet, create it, and reset it to the target commit.
     else:
-      self.handle.git.checkout('-b', branch_name, f'origin/{branch_name}')
-      self.handle.head.reset(commit=commit, index=True, working_tree=True)
+      return False
+
+  def _try_checkout_remote(self, branch_name: str, commit: git.Commit, force: bool):
+    """
+    Attempts to checkout the commit on the specified REMOTE branch, returns the success of the
+    request.
+    """
+
+    if Repository._does_remote_branch_have_commit(self.handle, branch_name, commit):
+      # Check if there is a local branch to match the remote branch.
+      local_branches = [branch.name for branch in self.handle.branches]
+
+      if branch_name in local_branches:
+        # Make sure the local branch is setup to track the expected remote branch.
+        local_branch = self.handle.branches[branch_name]
+        tracking_branch = self._verify_local_branch_has_correct_tracking_branch(local_branch)
+
+        # Make sure the local branch is not ahead of tracking branch, since we're moving the
+        # local HEAD, information would be lost.
+        if not force:
+          self._verify_local_commits_not_ahead(local_branch, tracking_branch)
+
+        # Good to go move the local branch HEAD to the target commit.
+        print(f"{self._relpath()}: checking out {local_branch.name}:{commit.hexsha}")
+        local_branch.checkout()
+        self.handle.head.reset(commit=commit, index=True, working_tree=True)
+        return True
+
+      # There is no local branch yet, create it, and reset it to the target commit.
+      else:
+        self.handle.git.checkout('-b', branch_name, f'origin/{branch_name}')
+        self.handle.head.reset(commit=commit, index=True, working_tree=True)
+        return True
+
+    else:
+      return False
 
   def _check_dangling_commit(self, commit):
     """

--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -16,6 +16,7 @@ class Repository:
     self.path = path
     self.name = os.path.basename(self.path)
     self.url = Repository._derive_url(path, url)
+    self.default_branch_name = ''
     self.fetched = False
     self.handle: git.Repo = []
     self._ensure()
@@ -46,7 +47,7 @@ class Repository:
     # Clone if necessary. At this point the mirror should exist regardless of whether the repository
     # exists. so ensure it first.
     cache = gordion.Cache()
-    mirror_path = cache.ensure_mirror(self.url)
+    mirror_path, self.default_branch_name = cache.ensure_mirror(self.url)
     if not Repository._exists(self.path):
       args = ['git', 'clone', '--reference', mirror_path, self.url, self.path]
       subprocess.check_call(args, stderr=subprocess.STDOUT)

--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -84,24 +84,26 @@ class Repository:
 
     # Check if a branch HAS NOT been specified.
     if not branch_name:
-      # Checkout the target commit in a detached HEAD state as long as it is not dangling.
-      self._check_dangling_commit(commit)
-      self.handle.git.checkout(commit)
-
-    # A branch HAS been specified
-    else:
-      if not self._try_checkout_branch_commit(branch_name, commit, force):
-        # We could not find the commit on a local or remote branch by the designated name, so just
-        # checkout the commit in a detached head state. Checkout the target commit in a detached
-        # HEAD state as long as it is not dangling.
+      # Try the default branch.
+      if not self._try_checkout_branch_commit(self.default_branch_name, commit, force):
+        # Checkout the target commit in a detached HEAD state as long as it is not dangling.
         self._check_dangling_commit(commit)
         self.handle.git.checkout(commit)
+
+    # A branch HAS been specified.
+    else:
+      # Try the specified branch.
+      if not self._try_checkout_branch_commit(branch_name, commit, force):
+        # Try the default branch.
+        if not self._try_checkout_branch_commit(self.default_branch_name, commit, force):
+          # Checkout the target commit in a detached HEAD state as long as it is not dangling.
+          self._check_dangling_commit(commit)
+          self.handle.git.checkout(commit)
 
   def _try_checkout_branch_commit(self, branch_name: str, commit: git.Commit, force: bool) -> bool:
     # Check if a local branch by the target name has the target commit.
     if Repository._does_local_branch_have_commit(self.handle, branch_name, commit):
       self._checkout_local_branch_commit(branch_name, commit, force)
-      # TODO make the function return
       return True
 
     # Tag is not on the specified local branch.

--- a/src/gordion/repository.py
+++ b/src/gordion/repository.py
@@ -92,30 +92,7 @@ class Repository:
     else:
       # Check if a local branch by the target name has the target commit.
       if Repository._does_local_branch_have_commit(self.handle, branch_name, commit):
-        local_branch = self.handle.branches[branch_name]
-
-        # Check if target commit is HEAD of local branch.
-        if commit.hexsha == local_branch.commit.hexsha:
-          local_branch.checkout()
-
-        # Target commit is in local branch history.
-        else:
-          # Need to fetch for this part of the logic.
-          self._fetch_once()
-
-          # Make sure the local branch is setup to track the expected remote branch.
-          local_branch = self.handle.branches[branch_name]
-          tracking_branch = self._verify_local_branch_has_correct_tracking_branch(local_branch)
-
-          # Make sure the local branch is not ahead of tracking branch, since we're moving the
-          # local HEAD, information would be lost.
-          if not force:
-            self._verify_local_commits_not_ahead(local_branch, tracking_branch)
-
-          # Good to go move the local branch HEAD to the target commit.
-          print(f"{self._relpath()}: checking out {local_branch.name}:{commit.hexsha}")
-          local_branch.checkout()
-          self.handle.head.reset(commit=commit, index=True, working_tree=True)
+        self._checkout_local_branch_commit(branch_name, commit, force)
 
       # Tag is not on the specified local branch.
       else:
@@ -154,6 +131,32 @@ class Repository:
           # Checkout the target commit in a detached HEAD state as long as it is not dangling.
           self._check_dangling_commit(commit)
           self.handle.git.checkout(commit)
+
+  def _checkout_local_branch_commit(self, branch_name: str, commit: git.Commit, force: bool):
+    local_branch = self.handle.branches[branch_name]
+
+    # Check if target commit is HEAD of local branch.
+    if commit == local_branch.commit:
+      local_branch.checkout()
+
+    # Target commit is in local branch history.
+    else:
+      # Need to fetch for this part of the logic.
+      self._fetch_once()
+
+      # Make sure the local branch is setup to track the expected remote branch.
+      local_branch = self.handle.branches[branch_name]
+      tracking_branch = self._verify_local_branch_has_correct_tracking_branch(local_branch)
+
+      # Make sure the local branch is not ahead of tracking branch, since we're moving the
+      # local HEAD, information would be lost.
+      if not force:
+        self._verify_local_commits_not_ahead(local_branch, tracking_branch)
+
+      # Good to go move the local branch HEAD to the target commit.
+      print(f"{self._relpath()}: checking out {local_branch.name}:{commit.hexsha}")
+      local_branch.checkout()
+      self.handle.head.reset(commit=commit, index=True, working_tree=True)
 
   def _check_dangling_commit(self, commit):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 import gordion
 import pytest
-import git
 
 assert 'TOXTEMPDIR' in os.environ, "you must run these tests using tox"
 
@@ -46,21 +45,21 @@ def repository_a():
 
 
 def git_clean(path):
-  if os.path.exists(path):
-    repo = git.Repo(path)
-    repo.git.reset('--hard')
-    repo.git.clean('-fdx')
-    repo.git.stash('clear')
+  if gordion.Repository._exists(path):
+    repo = gordion.Repository(path)
+    repo.handle.git.reset('--hard')
+    repo.handle.git.clean('-fdx')
+    repo.handle.git.stash('clear')
 
 
 def git_delete_non_develop_branches(path):
-  if os.path.exists(path):
-    repo = git.Repo(path)
-    repo.branches['develop'].checkout()
-    branches = list(repo.branches)
+  if gordion.Repository._exists(path):
+    repo = gordion.Repository(path)
+    repo.handle.branches['develop'].checkout()
+    branches = list(repo.handle.branches)
     for branch in branches:
       if branch.name != 'develop':
-        repo.delete_head(branch, force=True)
+        repo.handle.delete_head(branch, force=True)
 
 
 def recursive_git_blast(path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,10 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 @pytest.fixture(scope="session")
-def repo_a_session():
+def tree_a():
   """
-  Creates the repo_a object only once for the lifetime of this session. This is important so the
-  "fetch_once" doesn't fetch every test case, which saves time.
+  Creates the gordion.Tree interface for gordion_demo_a only once for the lifetime of this session.
+  This is important so the "fetch_once" doesn't fetch every test case, which saves time.
   """
   path = os.path.join(REPOS_DIR, 'gordion_demo_a')
   url = 'https://github.com/jacob-heathorn/gordion_demo_a.git'
@@ -21,8 +21,26 @@ def repo_a_session():
   store = gordion.Store()
   store.setup(path)
 
-  # Create the gordion repository Tree object.
+  # Create the gordion.Tree interface.
   repo = gordion.Tree(path, url)
+
+  yield repo
+
+
+@pytest.fixture(scope="session")
+def repository_a():
+  """
+  Creates the gordion.Repository interface for gordion_demo_a only once for the lifetime of this
+  session. This is important so the "fetch_once" doesn't fetch every test case, which saves time.
+  """
+  path = os.path.join(REPOS_DIR, 'gordion_demo_a')
+  url = 'https://github.com/jacob-heathorn/gordion_demo_a.git'
+
+  store = gordion.Store()
+  store.setup(path)
+
+  # Create the gordion.Repository interface.
+  repo = gordion.Repository(path, url)
 
   yield repo
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,9 +5,9 @@ from tests.conftest import recursive_git_blast
 
 
 @pytest.fixture
-def repo_a(repo_a_session):
+def demo_a(tree_a):
   """
-  This puts the repo_a object back into a well-known state for each test case.
+  This puts the gordion.Tree session object back into a well-known state for each test case.
   """
   # Setup
   #
@@ -16,46 +16,46 @@ def repo_a(repo_a_session):
   branch_name = 'develop'
 
   # Set the target branch/commit.
-  repo_a_session.update(tag, branch_name, force=True)
+  tree_a.update(tag, branch_name, force=True)
 
-  yield repo_a_session
+  yield tree_a
 
   # Cleanup.
-  recursive_git_blast(repo_a_session.path)
+  recursive_git_blast(tree_a.path)
 
   # Update to our known commit.
-  repo_a_session.update(tag, branch_name, force=True)
+  tree_a.update(tag, branch_name, force=True)
 
 
-def test_gordion_root(repo_a):
+def test_gordion_root(demo_a):
   """
   Verifies the gordion -r behavior.
   """
 
   # From top of repoA.
-  with gordion.utils.pushd(repo_a.path):
-    assert repo_a.path == gordion.app.root.gordion_root(os.getcwd())
+  with gordion.utils.pushd(demo_a.path):
+    assert demo_a.path == gordion.app.root.gordion_root(os.getcwd())
 
   # From the gordion directory in repoA.
-  with gordion.utils.pushd(os.path.join(repo_a.path, 'gordion')):
-    assert repo_a.path == gordion.app.root.gordion_root(os.getcwd())
+  with gordion.utils.pushd(os.path.join(demo_a.path, 'gordion')):
+    assert demo_a.path == gordion.app.root.gordion_root(os.getcwd())
 
   # From one level above repoA.
-  with gordion.utils.pushd(os.path.join(repo_a.path, '..')):
+  with gordion.utils.pushd(os.path.join(demo_a.path, '..')):
     with pytest.raises(gordion.NotAGordionRepositoryError):
       gordion.app.root.gordion_root(os.getcwd())
 
   # From repoB under repoA
-  with gordion.utils.pushd(os.path.join(repo_a.path, 'gordion', 'gordion_demo_b')):
-    assert repo_a.path == gordion.app.root.gordion_root(os.getcwd())
+  with gordion.utils.pushd(os.path.join(demo_a.path, 'gordion', 'gordion_demo_b')):
+    assert demo_a.path == gordion.app.root.gordion_root(os.getcwd())
 
   # Cause repoC to dangle and then try from there.
-  repo_a.yeditor.yaml_data['repositories']['gordion_demo_c']['path'] = '/heyo/gordion_demo_c'
-  repo_a.yeditor.save()
-  with gordion.utils.pushd(os.path.join(repo_a.path, 'gordion', 'gordion_demo_c')):
+  demo_a.yeditor.yaml_data['repositories']['gordion_demo_c']['path'] = '/heyo/gordion_demo_c'
+  demo_a.yeditor.save()
+  with gordion.utils.pushd(os.path.join(demo_a.path, 'gordion', 'gordion_demo_c')):
     with pytest.raises(gordion.DanglingGordionRepositoryError) as context:
       gordion.app.root.gordion_root(os.getcwd())
 
     expected = gordion.DanglingGordionRepositoryError(
-      os.path.join(repo_a.path, 'gordion', 'gordion_demo_c'), repo_a.path)
+      os.path.join(demo_a.path, 'gordion', 'gordion_demo_c'), demo_a.path)
     assert str(context.value) == str(expected)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -39,4 +39,9 @@ class TestCache(unittest.TestCase):
   def test_mirror(self):
     cache = gordion.Cache()
     cache.clean()
-    cache.ensure_mirror('https://github.com/jacob-heathorn/gordion_demo_a.git')
+    path, default_branch = cache.ensure_mirror(
+      'https://github.com/jacob-heathorn/gordion_demo_a.git')
+    self.assertEqual(path, os.path.join(os.environ['HOME'], '.local', 'share', 'gordion',
+                                        'mirrors', 'github.com', 'jacob-heathorn',
+                                        'gordion_demo_a'))
+    self.assertEqual(default_branch, 'develop')

--- a/tests/test_diamond.py
+++ b/tests/test_diamond.py
@@ -5,9 +5,9 @@ from tests.conftest import recursive_git_blast
 
 
 @pytest.fixture
-def repo_a(repo_a_session):
+def demo_a(tree_a):
   """
-  This puts the repo_a object back into a well-known state for each test case.
+  This puts the gordion.Tree session object back into a well-known state for each test case.
   """
   # Setup
   #
@@ -16,44 +16,44 @@ def repo_a(repo_a_session):
   branch_name = 'develop'
 
   # Set the target branch/commit.
-  repo_a_session.update(tag, branch_name, force=True)
+  tree_a.update(tag, branch_name, force=True)
 
-  yield repo_a_session
+  yield tree_a
 
   # Cleanup.
-  recursive_git_blast(repo_a_session.path)
+  recursive_git_blast(tree_a.path)
 
   # Update to our known commit.
-  repo_a_session.update(tag, branch_name, force=True)
+  tree_a.update(tag, branch_name, force=True)
 
 
-def test_same_repo_different_tag(repo_a):
+def test_same_demo_different_tag(demo_a):
   """
   Verifies update will error if two of the same repository reference have different tags.
   """
 
   # Add a commit to repository D.
-  repo_d = repo_a.children['gordion_demo_b'].children['gordion_demo_d']
-  repo_d.handle.git.commit('-m', "Empty commit for test_same_repo_different_tag", allow_empty=True)
+  demo_d = demo_a.children['gordion_demo_b'].children['gordion_demo_d']
+  demo_d.handle.git.commit('-m', "Empty commit for test_same_demo_different_tag", allow_empty=True)
 
   # Make B point to D's new commit but not C.
-  repo_b = repo_a.children['gordion_demo_b']
-  repo_b.yeditor.write_repository_tag('gordion_demo_d', repo_d.handle.head.commit.hexsha)
-  repo_b.handle.git.add(os.path.join(repo_b.path, 'gordion.yaml'))
-  repo_b.handle.git.commit('-m', "Point to latest D")
-  repo_a.yeditor.write_repository_tag('gordion_demo_b', repo_b.handle.head.commit.hexsha)
-  repo_a.handle.git.add(os.path.join(repo_a.path, 'gordion.yaml'))
-  repo_a.handle.git.commit('-m', "Point to latest B")
+  demo_b = demo_a.children['gordion_demo_b']
+  demo_b.yeditor.write_repository_tag('gordion_demo_d', demo_d.handle.head.commit.hexsha)
+  demo_b.handle.git.add(os.path.join(demo_b.path, 'gordion.yaml'))
+  demo_b.handle.git.commit('-m', "Point to latest D")
+  demo_a.yeditor.write_repository_tag('gordion_demo_b', demo_b.handle.head.commit.hexsha)
+  demo_a.handle.git.add(os.path.join(demo_a.path, 'gordion.yaml'))
+  demo_a.handle.git.commit('-m', "Point to latest B")
 
   # Save some information before the update.
-  b_ref_d = repo_a.children['gordion_demo_b'].children['gordion_demo_d']
-  b_ref_d_tag = repo_a.children['gordion_demo_b'].yeditor.read_repository_tag('gordion_demo_d')
-  c_ref_d = repo_a.children['gordion_demo_c'].children['gordion_demo_d']
-  c_ref_d_tag = repo_a.children['gordion_demo_c'].yeditor.read_repository_tag('gordion_demo_d')
+  b_ref_d = demo_a.children['gordion_demo_b'].children['gordion_demo_d']
+  b_ref_d_tag = demo_a.children['gordion_demo_b'].yeditor.read_repository_tag('gordion_demo_d')
+  c_ref_d = demo_a.children['gordion_demo_c'].children['gordion_demo_d']
+  c_ref_d_tag = demo_a.children['gordion_demo_c'].yeditor.read_repository_tag('gordion_demo_d')
 
   # Now update, it should raise error, tag mismatch.
   with pytest.raises(gordion.UpdateSameRepoDifferentTagError) as context:
-    repo_a.update(repo_a.handle.head.commit.hexsha, "develop")
+    demo_a.update(demo_a.handle.head.commit.hexsha, "develop")
 
   # Verify the exception.
   expected = gordion.UpdateSameRepoDifferentTagError(c_ref_d.path, c_ref_d._listed_path(),
@@ -62,40 +62,40 @@ def test_same_repo_different_tag(repo_a):
   assert str(context.value) == str(expected)
 
 
-def test_same_repo_different_path(repo_a):
+def test_same_demo_different_path(demo_a):
   """
   Verifies update will error if the same repository is attempted to be cloned at different paths.
   """
 
-  repo_b = repo_a.children['gordion_demo_b']
-  repo_c = repo_a.children['gordion_demo_c']
+  demo_b = demo_a.children['gordion_demo_b']
+  demo_c = demo_a.children['gordion_demo_c']
 
   with pytest.raises(gordion.UpdateSameRepoDifferentPathError) as context:
-    repo_a.update("8659bcd4e68ac3e0c0e2f55e6bd03296007a0a47", "test_duplicate_repo_path_mismatch")
+    demo_a.update("8659bcd4e68ac3e0c0e2f55e6bd03296007a0a47", "test_duplicate_repo_path_mismatch")
 
-  expected = gordion.UpdateSameRepoDifferentPathError(repo_c.path, repo_b.path, repo_b.url)
+  expected = gordion.UpdateSameRepoDifferentPathError(demo_c.path, demo_b.path, demo_b.url)
   assert str(context.value) == str(expected)
 
 
-def test_different_repo_same_path(repo_a):
+def test_different_repo_same_path(demo_a):
   """
   Verifies that an error is generated if a different repository is attempted to be cloned to the
   same gordion path.
   """
 
   with pytest.raises(gordion.UpdateDifferentRepoSamePathError) as context:
-    repo_a.update('92d294df03a6bbf7ef43b60a0255adca08671328', "test_different_repo_same_path")
+    demo_a.update('92d294df03a6bbf7ef43b60a0255adca08671328', "test_different_repo_same_path")
 
-  repo_b = repo_a.children['gordion_demo_b']
+  demo_b = demo_a.children['gordion_demo_b']
 
-  target_path = os.path.join(repo_a.path, 'gordion', 'gordion_demo_b')
+  target_path = os.path.join(demo_a.path, 'gordion', 'gordion_demo_b')
   target_url = 'https://github.com/jacob-heathorn/gordion_demo_d.git'
-  expected = gordion.UpdateDifferentRepoSamePathError(target_path, target_url, repo_b.path,
-                                                      repo_b.url)
+  expected = gordion.UpdateDifferentRepoSamePathError(target_path, target_url, demo_b.path,
+                                                      demo_b.url)
   assert str(context.value) == str(expected)
 
 
-def test_non_default_path(repo_a):
+def test_non_default_path(demo_a):
   """
   Verifies that a repository can be cloned at a non-default gpath. And that the non-default path can
   be cleaned up if it is moved back.
@@ -103,157 +103,157 @@ def test_non_default_path(repo_a):
 
   # Put repo B at in a non-default path, update and verify it exists, and the origional one has been
   # removed.
-  repo_a.yeditor.yaml_data['repositories']['gordion_demo_b']['path'] = '/heyo/gordion_demo_b'
-  repo_a.yeditor.save()
-  repo_a.update(repo_a.handle.head.commit.hexsha, "develop")
-  repo_b = repo_a.children['gordion_demo_b']
-  assert repo_b.path == os.path.join(repo_a.path, 'gordion', 'heyo', 'gordion_demo_b')
-  assert repo_b.handle.head.commit.hexsha == repo_a.yeditor.read_repository_tag('gordion_demo_b')
-  assert not os.path.isdir(os.path.join(repo_a.path, 'gordion', 'gordion_demo_b'))
+  demo_a.yeditor.yaml_data['repositories']['gordion_demo_b']['path'] = '/heyo/gordion_demo_b'
+  demo_a.yeditor.save()
+  demo_a.update(demo_a.handle.head.commit.hexsha, "develop")
+  demo_b = demo_a.children['gordion_demo_b']
+  assert demo_b.path == os.path.join(demo_a.path, 'gordion', 'heyo', 'gordion_demo_b')
+  assert demo_b.handle.head.commit.hexsha == demo_a.yeditor.read_repository_tag('gordion_demo_b')
+  assert not os.path.isdir(os.path.join(demo_a.path, 'gordion', 'gordion_demo_b'))
 
   # Put repository back to default path, verify old path is deleted.
-  repo_a.yeditor.yaml_data['repositories']['gordion_demo_b']['path'] = '/gordion_demo_b'
-  repo_a.yeditor.save()
-  repo_a.update(repo_a.handle.head.commit.hexsha, "develop")
-  repo_b = repo_a.children['gordion_demo_b']
-  assert repo_b.path == os.path.join(repo_a.path, 'gordion', 'gordion_demo_b')
-  assert repo_b.handle.head.commit.hexsha == repo_a.yeditor.read_repository_tag('gordion_demo_b')
-  assert not os.path.isdir(os.path.join(repo_a.path, 'gordion', 'heyo'))
+  demo_a.yeditor.yaml_data['repositories']['gordion_demo_b']['path'] = '/gordion_demo_b'
+  demo_a.yeditor.save()
+  demo_a.update(demo_a.handle.head.commit.hexsha, "develop")
+  demo_b = demo_a.children['gordion_demo_b']
+  assert demo_b.path == os.path.join(demo_a.path, 'gordion', 'gordion_demo_b')
+  assert demo_b.handle.head.commit.hexsha == demo_a.yeditor.read_repository_tag('gordion_demo_b')
+  assert not os.path.isdir(os.path.join(demo_a.path, 'gordion', 'heyo'))
 
 
-def test_unsafe_remove_dirty(repo_a):
+def test_unsafe_remove_dirty(demo_a):
   """
   Verifies that an error is generated if the update will attempt to cleanup(remove) a repository
   that has dirty changes.
   """
 
   # Make the demo_c dirty by adding an empty file.
-  repo_c = repo_a.children['gordion_demo_c']
-  touchfile = os.path.join(repo_c.path, 'touch.txt')
+  demo_c = demo_a.children['gordion_demo_c']
+  touchfile = os.path.join(demo_c.path, 'touch.txt')
   with open(touchfile, 'w'):
     pass
 
-  assert repo_c.handle.is_dirty(untracked_files=True)
+  assert demo_c.handle.is_dirty(untracked_files=True)
 
   with pytest.raises(gordion.UnsafeRemoveDirty) as context:
-    repo_a.update('55f619c7af1cdc3ed13487c3aab050b492e655eb', 'test_unsafe_remove_dirty')
+    demo_a.update('55f619c7af1cdc3ed13487c3aab050b492e655eb', 'test_unsafe_remove_dirty')
 
-  expected = gordion.UnsafeRemoveDirty(repo_c.path)
+  expected = gordion.UnsafeRemoveDirty(demo_c.path)
   assert str(context.value) == str(expected)
 
 
-def test_unsafe_remove_local_branch_no_tracking_branch(repo_a):
+def test_unsafe_remove_local_branch_no_tracking_branch(demo_a):
   """
   Verifies that an error is generated if the update attempts to delete a repository that has local
   branches without a remote tracking branch.
   """
 
   # Checkout a new local branch on repo B.
-  repo_b = repo_a.children['gordion_demo_b']
-  new_branch = repo_b.handle.create_head("new_branch")
+  demo_b = demo_a.children['gordion_demo_b']
+  new_branch = demo_b.handle.create_head("new_branch")
   new_branch.checkout()
 
   # Remove repo B from Repo A's yaml file.
-  del repo_a.yeditor.yaml_data['repositories']['gordion_demo_b']
-  repo_a.yeditor.save()
+  del demo_a.yeditor.yaml_data['repositories']['gordion_demo_b']
+  demo_a.yeditor.save()
 
   # Verify update errors because we are deleting the repository and the local branch does not have a
   # tracking branch.
   with pytest.raises(gordion.UnsafeRemoveLocalBranchNoTrackingBranch) as context:
-    repo_a.update(repo_a.handle.head.commit.hexsha, "develop")
-  expected = gordion.UnsafeRemoveLocalBranchNoTrackingBranch(repo_b.path, "new_branch")
+    demo_a.update(demo_a.handle.head.commit.hexsha, "develop")
+  expected = gordion.UnsafeRemoveLocalBranchNoTrackingBranch(demo_b.path, "new_branch")
   assert str(context.value) == str(expected)
 
 
-def test_unsafe_remove_local_branch_ahead(repo_a):
+def test_unsafe_remove_local_branch_ahead(demo_a):
   """
   Verifies that an error is generated if the update attempts to delete a repository that has local
   branches that are ahead of their remote tracking branches.
   """
 
   # Remove repo B from Repo A's yaml file.
-  del repo_a.yeditor.yaml_data['repositories']['gordion_demo_b']
-  repo_a.yeditor.save()
+  del demo_a.yeditor.yaml_data['repositories']['gordion_demo_b']
+  demo_a.yeditor.save()
 
   # Now checkout a branch on Repo B that has a remote tracking branch.
-  repo_b = repo_a.children['gordion_demo_b']
-  repo_b.handle.git.checkout('-b', 'test_unsafe_remove_local_branch_unsaved',
+  demo_b = demo_a.children['gordion_demo_b']
+  demo_b.handle.git.checkout('-b', 'test_unsafe_remove_local_branch_unsaved',
                              'origin/test_unsafe_remove_local_branch_unsaved')
-  repo_b.handle.git.commit('-m', "Empty commit for test_unsafe_remove_local_branch_unsaved",
+  demo_b.handle.git.commit('-m', "Empty commit for test_unsafe_remove_local_branch_unsaved",
                            allow_empty=True)
 
   # Verify update errors because we are deleting the repository and the local branch has an unsaved
   # commit.
   with pytest.raises(gordion.UnsafeRemoveLocalBranchAhead) as context:
-    repo_a.update(repo_a.handle.head.commit.hexsha, "develop")
-  expected = gordion.UnsafeRemoveLocalBranchAhead(repo_b.path,
+    demo_a.update(demo_a.handle.head.commit.hexsha, "develop")
+  expected = gordion.UnsafeRemoveLocalBranchAhead(demo_b.path,
                                                   "test_unsafe_remove_local_branch_unsaved",
                                                   "origin/test_unsafe_remove_local_branch_unsaved",
                                                   1)
   assert str(context.value) == str(expected)
 
 
-def test_unsafe_remove_stashes(repo_a):
+def test_unsafe_remove_stashes(demo_a):
   """
   Verifies that an error is generated if the update attempts to delete a repository that has
   stashes.
   """
 
   # Remove repo B from Repo A's yaml file.
-  del repo_a.yeditor.yaml_data['repositories']['gordion_demo_b']
-  repo_a.yeditor.save()
+  del demo_a.yeditor.yaml_data['repositories']['gordion_demo_b']
+  demo_a.yeditor.save()
 
   # Create a stash on repo B.
-  repo_b = repo_a.children['gordion_demo_b']
-  file_path = os.path.join(repo_b.path, 'README.md')
+  demo_b = demo_a.children['gordion_demo_b']
+  file_path = os.path.join(demo_b.path, 'README.md')
   with open(file_path, 'w') as file:
     file.write('test_unsafe_remove_stashes wrote this.\n')
-  repo_b.handle.git.stash("save")
+  demo_b.handle.git.stash("save")
 
   # Verify update errors because we are deleting the repository while it has stashes.
-  stashes = repo_b.handle.git.stash("list")
+  stashes = demo_b.handle.git.stash("list")
   with pytest.raises(gordion.UnsafeRemoveStashes) as context:
-    repo_a.update(repo_a.handle.head.commit.hexsha, "develop")
-  expected = gordion.UnsafeRemoveStashes(repo_b.path, stashes)
+    demo_a.update(demo_a.handle.head.commit.hexsha, "develop")
+  expected = gordion.UnsafeRemoveStashes(demo_b.path, stashes)
   assert str(context.value) == str(expected)
 
 
-def test_name_path_mismatch(repo_a):
+def test_name_path_mismatch(demo_a):
   """
   Verifies that an error is generated if the optional path property does not match the repository
   name.
   """
-  repo_a.yeditor.yaml_data['repositories']['gordion_demo_b']['path'] = '/subdir/not_gordion_demo_b'
-  repo_a.yeditor.save()
+  demo_a.yeditor.yaml_data['repositories']['gordion_demo_b']['path'] = '/subdir/not_gordion_demo_b'
+  demo_a.yeditor.save()
   with pytest.raises(gordion.BadRepositoryNamePathMismach) as context:
-    repo_a.update(repo_a.handle.head.commit.hexsha, "develop")
+    demo_a.update(demo_a.handle.head.commit.hexsha, "develop")
 
-  expected = gordion.BadRepositoryNamePathMismach(repo_a.yeditor.fullfile,
+  expected = gordion.BadRepositoryNamePathMismach(demo_a.yeditor.fullfile,
                                                   '/subdir/not_gordion_demo_b', 'gordion_demo_b')
   assert str(context.value) == str(expected)
 
 
-def test_dangling_commit(repo_a):
+def test_dangling_commit(demo_a):
   """
   Verifies update will error if a child target commit is dangling.
   """
 
   # Create a dangling commit by committing something, then deleting it. First make an arbitrary
   # change to repo B.
-  repo_b = repo_a.children['gordion_demo_b']
-  repo_b.handle.git.commit('-m', "Empty commit for test_dangling_commit", allow_empty=True)
-  empty_commit = repo_b.handle.head.commit
+  demo_b = demo_a.children['gordion_demo_b']
+  demo_b.handle.git.commit('-m', "Empty commit for test_dangling_commit", allow_empty=True)
+  empty_commit = demo_b.handle.head.commit
 
   # Now delete the commit (checkout HEAD~1).
-  repo_b.handle.head.reset('HEAD~1', index=True, working_tree=True)
+  demo_b.handle.head.reset('HEAD~1', index=True, working_tree=True)
 
   # Now add the empty commit to the parent gordion.yaml.
-  repo_a.yeditor.write_repository_tag('gordion_demo_b', empty_commit.hexsha)
-  repo_a.yeditor.save()
+  demo_a.yeditor.write_repository_tag('gordion_demo_b', empty_commit.hexsha)
+  demo_a.yeditor.save()
 
   # Now update should error commit is dangling ehh.
   with pytest.raises(gordion.DanglingCommitError) as context:
-    repo_a.update(repo_a.handle.head.commit.hexsha, "develop")
+    demo_a.update(demo_a.handle.head.commit.hexsha, "develop")
 
-  expected = gordion.DanglingCommitError(repo_b.path, empty_commit.hexsha)
+  expected = gordion.DanglingCommitError(demo_b.path, empty_commit.hexsha)
   assert str(context.value) == str(expected)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,3 +1,6 @@
+# Tests for the gordion.Repository interface. That means we are dealing with a single repository,
+# which does not recursively manage children.
+
 import os
 import gordion
 import pytest

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -19,9 +19,9 @@ def test_exists():
 
 
 @pytest.fixture
-def repo_a(repo_a_session):
+def demo_a(repository_a):
   """
-  This puts the repo_a object back into a well-known state for each test case.
+  This puts the gordion.Repository session object back into a well-known state for each test case.
   """
 
   # Set the object to a known commit on the test_single branch.
@@ -29,199 +29,199 @@ def repo_a(repo_a_session):
   branch_name = 'test_single'
 
   # Set the target branch/commit
-  repo_a_session.update(tag, branch_name, force=True)
-  yield repo_a_session
+  repository_a.update(tag, branch_name, force=True)
+  yield repository_a
 
   # Cleanup.
-  recursive_git_blast(repo_a_session.path)
+  recursive_git_blast(repository_a.path)
 
   # Update to our known commit.
-  repo_a_session.update(tag, branch_name, force=True)
+  repository_a.update(tag, branch_name, force=True)
 
 
-def test_verify_tag(repo_a):
+def test_verify_tag(demo_a):
   # Verify HEAD of active branch exists.
-  repo_a._verify_tag(repo_a.handle.head.commit.hexsha)
+  demo_a._verify_tag(demo_a.handle.head.commit.hexsha)
 
   # Verify older commit of active branch exists.
-  repo_a._verify_tag(repo_a.handle.head.commit.parents[0].hexsha)
+  demo_a._verify_tag(demo_a.handle.head.commit.parents[0].hexsha)
 
   # Verify a tag that only exists on a different remote branch (test_single_1) in fact exists.
-  repo_a._verify_tag('05090461f38c8b725d89bf30a31c716383778b48')
+  demo_a._verify_tag('05090461f38c8b725d89bf30a31c716383778b48')
 
   # Verify that an ill-formed commit will raise an error.
   with pytest.raises(git.BadName):
-    repo_a._verify_tag("123")
+    demo_a._verify_tag("123")
 
 
-def test_does_local_branch_have_commit(repo_a):
+def test_does_local_branch_have_commit(demo_a):
   """
   Verifies the behavior of _does_local_branch_have_commit()
   """
 
   # Verify HEAD of active branch returns true
-  assert repo_a.handle.active_branch.name == 'test_single'
-  head_commit = repo_a.handle.active_branch.commit
+  assert demo_a.handle.active_branch.name == 'test_single'
+  head_commit = demo_a.handle.active_branch.commit
   assert gordion.Repository._does_local_branch_have_commit(
-      repo_a.handle, 'test_single', head_commit)
+      demo_a.handle, 'test_single', head_commit)
 
   # Verify older commit of active branch returns true
   older_commit = head_commit.parents[0]
   assert gordion.Repository._does_local_branch_have_commit(
-      repo_a.handle, 'test_single', older_commit)
+      demo_a.handle, 'test_single', older_commit)
 
   # Verify remote branch (test_single_1) that is not local returns false.
   assert not gordion.Repository._does_local_branch_have_commit(
-      repo_a.handle, 'test_single_1', head_commit)
+      demo_a.handle, 'test_single_1', head_commit)
 
   # Now checkout "test_single_1" so it exists locally, then switch back to "test_single". The same
   # check should return true.
-  repo_a.handle.git.checkout('-b', 'test_single_1', 'origin/test_single_1')
-  repo_a.handle.branches['test_single'].checkout()
+  demo_a.handle.git.checkout('-b', 'test_single_1', 'origin/test_single_1')
+  demo_a.handle.branches['test_single'].checkout()
   assert gordion.Repository._does_local_branch_have_commit(
-      repo_a.handle, 'test_single_1', head_commit)
+      demo_a.handle, 'test_single_1', head_commit)
 
   # Verfiy commit on remote but not on local returns false.
-  future_commit = repo_a._verify_tag('04518b39225d45f69fc9a2f9f5c0dba1fe6a6227')
+  future_commit = demo_a._verify_tag('04518b39225d45f69fc9a2f9f5c0dba1fe6a6227')
   assert not gordion.Repository._does_local_branch_have_commit(
-      repo_a.handle, 'test_single', future_commit)
+      demo_a.handle, 'test_single', future_commit)
 
 
-def test_update_active_branch_commits_ahead(repo_a):
+def test_update_active_branch_commits_ahead(demo_a):
   """
   Verifies that updating the active branch will ERROR if it is ahead of the remote.
   """
-  baseline_commit = repo_a.handle.head.commit.hexsha
+  baseline_commit = demo_a.handle.head.commit.hexsha
 
   # Create newer commit on the active 'test_single' branch.
-  repo_a.handle.index.commit("Empty commit for testing")
+  demo_a.handle.index.commit("Empty commit for testing")
 
   # Verify update error. User needs to save the commits, or force the update.
   with pytest.raises(gordion.UpdateLocalBranchAheadError) as context:
-    repo_a.update(baseline_commit, "test_single")
-  expected = gordion.UpdateLocalBranchAheadError(repo_a.path, 'test_single', 'origin/test_single',
+    demo_a.update(baseline_commit, "test_single")
+  expected = gordion.UpdateLocalBranchAheadError(demo_a.path, 'test_single', 'origin/test_single',
                                                  1)
   assert str(context.value) == str(expected)
 
 
-def test_update_nonactive_local_branch_commits_ahead(repo_a):
+def test_update_nonactive_local_branch_commits_ahead(demo_a):
   """
   Verifies that updating a non-active local branch will ERROR if it is ahead of the remote.
   """
   # Add a commit to "test_single_1"
-  repo_a.handle.git.checkout('-b', 'test_single_1', 'origin/test_single_1')
-  repo_a.handle.index.commit("Empty commit for testing")
-  repo_a.handle.branches['test_single'].checkout()
+  demo_a.handle.git.checkout('-b', 'test_single_1', 'origin/test_single_1')
+  demo_a.handle.index.commit("Empty commit for testing")
+  demo_a.handle.branches['test_single'].checkout()
 
   # Verify update error. User needs to save the commits, or force the update.
   # NOTE: the commit needs to move, so checkout HEAD~1
   with pytest.raises(gordion.UpdateLocalBranchAheadError) as context:
-    repo_a.update(repo_a.handle.commit('HEAD~1').hexsha, "test_single_1")
-  expected = gordion.UpdateLocalBranchAheadError(repo_a.path, 'test_single_1',
+    demo_a.update(demo_a.handle.commit('HEAD~1').hexsha, "test_single_1")
+  expected = gordion.UpdateLocalBranchAheadError(demo_a.path, 'test_single_1',
                                                  'origin/test_single_1', 1)
   assert str(context.value) == str(expected)
 
 
-def test_update_local_branch_no_remote(repo_a):
+def test_update_local_branch_no_remote(demo_a):
   """
   Verifies that updating a local branch will ERROR if it does not have a remote tracking branch.
   """
 
   # Create a new local branch, with no remote, and checkout develop again."
-  repo_a.handle.git.checkout('-b', 'test_branch_no_remote')
-  repo_a.handle.branches['test_single'].checkout()
+  demo_a.handle.git.checkout('-b', 'test_branch_no_remote')
+  demo_a.handle.branches['test_single'].checkout()
 
   # Point the update to test_branch_no_remote:HEAD~1. Verify update error. User needs to create a
   # tracking branch.
   branch_name = 'test_branch_no_remote'
-  tag = repo_a.handle.branches['test_branch_no_remote'].commit.parents[0].hexsha
+  tag = demo_a.handle.branches['test_branch_no_remote'].commit.parents[0].hexsha
 
   # Verify update error. User needs to create a tracking branch.
   with pytest.raises(gordion.UpdateNoTrackingBranchError) as context:
-    repo_a.update(tag, branch_name)
-  expected = gordion.UpdateNoTrackingBranchError(repo_a.path, 'test_branch_no_remote')
+    demo_a.update(tag, branch_name)
+  expected = gordion.UpdateNoTrackingBranchError(demo_a.path, 'test_branch_no_remote')
   assert str(context.value) == str(expected)
 
 
-def test_does_remote_branch_have_commit(repo_a):
+def test_does_remote_branch_have_commit(demo_a):
   """
   Verifies behavior of _does_remote_branch_have_commit()
   """
 
   # Verify a commit is on remote branch but not local.
-  commit = repo_a._verify_tag('04518b39225d45f69fc9a2f9f5c0dba1fe6a6227')
-  assert not gordion.Repository._does_local_branch_have_commit(repo_a.handle, 'test_single', commit)
-  assert gordion.Repository._does_remote_branch_have_commit(repo_a.handle, 'test_single', commit)
+  commit = demo_a._verify_tag('04518b39225d45f69fc9a2f9f5c0dba1fe6a6227')
+  assert not gordion.Repository._does_local_branch_have_commit(demo_a.handle, 'test_single', commit)
+  assert gordion.Repository._does_remote_branch_have_commit(demo_a.handle, 'test_single', commit)
 
   # If remote branch does not exist, it just returns false.
-  assert not gordion.Repository._does_remote_branch_have_commit(repo_a.handle, 'noname', commit)
+  assert not gordion.Repository._does_remote_branch_have_commit(demo_a.handle, 'noname', commit)
 
   # Verifies a commit on local but not remote.
-  repo_a.handle.index.commit("Empty commit test_does_remote_branch_have_commit()")
-  commit = repo_a.handle.active_branch.commit
-  assert gordion.Repository._does_local_branch_have_commit(repo_a.handle, 'test_single', commit)
+  demo_a.handle.index.commit("Empty commit test_does_remote_branch_have_commit()")
+  commit = demo_a.handle.active_branch.commit
+  assert gordion.Repository._does_local_branch_have_commit(demo_a.handle, 'test_single', commit)
   assert not gordion.Repository._does_remote_branch_have_commit(
-      repo_a.handle, 'test_single', commit)
+      demo_a.handle, 'test_single', commit)
 
 
-def test_update_remote_branch_only(repo_a):
+def test_update_remote_branch_only(demo_a):
   """
   Verifies that update will create a new local branch to track the remote branch if it does not
   exist yet AND the remote branch has the target commit.
   """
-  new_commit = repo_a.handle.commit('HEAD~1').hexsha
-  repo_a.update(new_commit, "test_single_1")
-  assert repo_a.handle.head.reference.name == "test_single_1"
-  assert repo_a.handle.head.commit.hexsha == new_commit
+  new_commit = demo_a.handle.commit('HEAD~1').hexsha
+  demo_a.update(new_commit, "test_single_1")
+  assert demo_a.handle.head.reference.name == "test_single_1"
+  assert demo_a.handle.head.commit.hexsha == new_commit
 
 
-def test_update_local_fastforward(repo_a):
+def test_update_local_fastforward(demo_a):
   """
   If there is a local branch, but it does not contain the commit, but the remote branch does
   contain the commit, update will fastforward.
   """
 
   # Choose a tag ahead of our baseline commit.
-  repo_a.update('a415fa52649601f17fccf6d17616281213b117b8', "test_single")
+  demo_a.update('a415fa52649601f17fccf6d17616281213b117b8', "test_single")
 
 
-def test_local_branch_wrong_tracking_branch(repo_a):
+def test_local_branch_wrong_tracking_branch(demo_a):
   """
   If there is a local branch that matches the remote branch by name, but it has the wrong tracking
   branch, error.
   """
-  baseline_commit = repo_a.handle.head.commit.hexsha
+  baseline_commit = demo_a.handle.head.commit.hexsha
 
   # Checkout "test_single_1" locally but link it to the wrong remote branch.
-  repo_a.handle.git.checkout('-b', 'test_single_1', 'origin/test_single')
+  demo_a.handle.git.checkout('-b', 'test_single_1', 'origin/test_single')
   with pytest.raises(gordion.UpdateWrongTrackingBranchError) as context:
-    repo_a.update(baseline_commit, "test_single_1")
-  expected = gordion.UpdateWrongTrackingBranchError(repo_a.path, 'test_single_1',
+    demo_a.update(baseline_commit, "test_single_1")
+  expected = gordion.UpdateWrongTrackingBranchError(demo_a.path, 'test_single_1',
                                                     'origin/test_single')
   assert str(context.value) == str(expected)
 
 
-def test_detached_head_unsaved_commit(repo_a):
+def test_detached_head_unsaved_commit(demo_a):
   """
   Verifies update will ERROR if we are in a detached head state, and the HEAD commit does not
   exist on a branch somewhere.
   """
   # Go to detached HEAD state.
-  baseline_commit = repo_a.handle.head.commit.hexsha
-  repo_a.handle.git.checkout(baseline_commit)
-  assert repo_a.handle.head.is_detached
+  baseline_commit = demo_a.handle.head.commit.hexsha
+  demo_a.handle.git.checkout(baseline_commit)
+  assert demo_a.handle.head.is_detached
 
   # Now add a commit.
-  repo_a.handle.index.commit("Commit while in detached HEAD state.")
+  demo_a.handle.index.commit("Commit while in detached HEAD state.")
 
   # Now verify that update errors.
   with pytest.raises(gordion.UpdateDetachedHeadNotSavedError) as context:
-    repo_a.update(baseline_commit, "test_single")
-  expected = gordion.UpdateDetachedHeadNotSavedError(repo_a.path)
+    demo_a.update(baseline_commit, "test_single")
+  expected = gordion.UpdateDetachedHeadNotSavedError(demo_a.path)
   assert str(context.value) == str(expected)
 
 
-def test_requested_branch_does_not_have_commit(repo_a):
+def test_requested_branch_does_not_have_commit(demo_a):
   """
   Verifies that update will checkout will first try the default branch, then checkout in detached
   head state if it cannot find the commit on the specified branch.
@@ -229,61 +229,61 @@ def test_requested_branch_does_not_have_commit(repo_a):
 
   # If the commit moves, and exists on the default branch but not the requested branch, it will go
   # there. Choose a commit on develop but not test_single_1.
-  new_commit = repo_a._verify_tag('8a477c37ae584072dd1c7909c5000f5e2677fec5')
-  repo_a.update(new_commit, "test_single_1")
-  assert repo_a.handle.active_branch.name == "develop"
-  assert repo_a.handle.head.commit == new_commit
+  new_commit = demo_a._verify_tag('8a477c37ae584072dd1c7909c5000f5e2677fec5')
+  demo_a.update(new_commit, "test_single_1")
+  assert demo_a.handle.active_branch.name == "develop"
+  assert demo_a.handle.head.commit == new_commit
 
   # If the commit moves, and exists on a non-default branch, but not the requested branch, it will
   # checkout detached HEAD. Choose a commit that exists on test_single_1 only.
-  new_commit = repo_a._verify_tag('05090461f38c8b725d89bf30a31c716383778b48')
-  repo_a.update(new_commit, "test_single")
-  assert repo_a.handle.head.is_detached
-  assert repo_a.handle.head.commit == new_commit
+  new_commit = demo_a._verify_tag('05090461f38c8b725d89bf30a31c716383778b48')
+  demo_a.update(new_commit, "test_single")
+  assert demo_a.handle.head.is_detached
+  assert demo_a.handle.head.commit == new_commit
 
 
-def test_dont_specify_branch(repo_a):
+def test_dont_specify_branch(demo_a):
   """
   Verifies that if you don't specify the branch, it will checkout the commit on the default branch
   if it exists there. If it doesn't exist there it will check it out in a detached head state.
   """
   # If commit does not move, it'll stay on the branch checked out.
-  baseline_commit = repo_a.handle.head.commit
-  repo_a.update(baseline_commit, None)
-  assert not repo_a.handle.head.is_detached
-  assert repo_a.handle.active_branch.name == "test_single"
-  assert repo_a.handle.head.commit == baseline_commit
+  baseline_commit = demo_a.handle.head.commit
+  demo_a.update(baseline_commit, None)
+  assert not demo_a.handle.head.is_detached
+  assert demo_a.handle.active_branch.name == "test_single"
+  assert demo_a.handle.head.commit == baseline_commit
 
   # If the commit moves, and exists on the default branch (develop) it will go there. Choose a
   # commit that only exists on develop branch.
-  new_commit = repo_a._verify_tag('8a477c37ae584072dd1c7909c5000f5e2677fec5')
-  repo_a.update(new_commit, None)
-  assert repo_a.handle.active_branch.name == "develop"
-  assert repo_a.handle.head.commit == new_commit
+  new_commit = demo_a._verify_tag('8a477c37ae584072dd1c7909c5000f5e2677fec5')
+  demo_a.update(new_commit, None)
+  assert demo_a.handle.active_branch.name == "develop"
+  assert demo_a.handle.head.commit == new_commit
 
   # If the commit does not exist on the default branch, it'll checkout in detached HEAD state.
-  repo_a.update(baseline_commit, None)
-  assert repo_a.handle.head.is_detached
-  assert repo_a.handle.head.commit == baseline_commit
+  demo_a.update(baseline_commit, None)
+  assert demo_a.handle.head.is_detached
+  assert demo_a.handle.head.commit == baseline_commit
 
 
-def test_update_dirty_repo(repo_a):
+def test_update_dirty_repo(demo_a):
   """
   Verifies update will error if the repository is dirty and the HEAD is about to move.
   """
 
   # Make an arbitrary change.
-  file_path = os.path.join(repo_a.path, 'README.md')
+  file_path = os.path.join(demo_a.path, 'README.md')
   with open(file_path, 'w') as file:
     file.write('test_uncommitted_edits wrote this.\n')
 
   # Attempt to move the HEAD and verify error.
-  tag = repo_a.handle.head.commit.parents[0].hexsha
+  tag = demo_a.handle.head.commit.parents[0].hexsha
   with pytest.raises(gordion.UpdateRepoIsDirtyError) as context:
-    repo_a.update(tag, "test_single")
-  expected = gordion.UpdateRepoIsDirtyError(repo_a.path)
+    demo_a.update(tag, "test_single")
+  expected = gordion.UpdateRepoIsDirtyError(demo_a.path)
   assert str(context.value) == str(expected)
 
   # If you don't move the HEAD, but change the branch while it's dirty, it's OK actually.
-  tag = repo_a.handle.head.commit.hexsha
-  repo_a.update(tag, "test_single")
+  tag = demo_a.handle.head.commit.hexsha
+  demo_a.update(tag, "test_single")

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -201,19 +201,6 @@ def test_local_branch_wrong_tracking_branch(repo_a):
   assert str(context.value) == str(expected)
 
 
-def test_branch_does_not_have_commit_but_commit_exists(repo_a):
-  """
-  Verifies that update will checkout a commit in a detached head state if it exists,
-  but it cannot find it on the specified branch.
-  """
-
-  # Choose a tag that exists on 'test_single_1' but not on test_single.
-  tag = '05090461f38c8b725d89bf30a31c716383778b48'
-  repo_a.update(tag, "test_single")
-  assert repo_a.handle.head.is_detached
-  assert repo_a.handle.head.commit.hexsha == tag
-
-
 def test_detached_head_unsaved_commit(repo_a):
   """
   Verifies update will ERROR if we are in a detached head state, and the HEAD commit does not
@@ -234,23 +221,50 @@ def test_detached_head_unsaved_commit(repo_a):
   assert str(context.value) == str(expected)
 
 
+def test_requested_branch_does_not_have_commit(repo_a):
+  """
+  Verifies that update will checkout will first try the default branch, then checkout in detached
+  head state if it cannot find the commit on the specified branch.
+  """
+
+  # If the commit moves, and exists on the default branch but not the requested branch, it will go
+  # there. Choose a commit on develop but not test_single_1.
+  new_commit = repo_a._verify_tag('8a477c37ae584072dd1c7909c5000f5e2677fec5')
+  repo_a.update(new_commit, "test_single_1")
+  assert repo_a.handle.active_branch.name == "develop"
+  assert repo_a.handle.head.commit == new_commit
+
+  # If the commit moves, and exists on a non-default branch, but not the requested branch, it will
+  # checkout detached HEAD. Choose a commit that exists on test_single_1 only.
+  new_commit = repo_a._verify_tag('05090461f38c8b725d89bf30a31c716383778b48')
+  repo_a.update(new_commit, "test_single")
+  assert repo_a.handle.head.is_detached
+  assert repo_a.handle.head.commit == new_commit
+
+
 def test_dont_specify_branch(repo_a):
   """
-  Verifies that if you don't specify the branch, it will checkout the commit in detached head
-  state (as long as the commit is moving).
+  Verifies that if you don't specify the branch, it will checkout the commit on the default branch
+  if it exists there. If it doesn't exist there it will check it out in a detached head state.
   """
   # If commit does not move, it'll stay on the branch checked out.
-  baseline_commit = repo_a.handle.head.commit.hexsha
+  baseline_commit = repo_a.handle.head.commit
   repo_a.update(baseline_commit, None)
   assert not repo_a.handle.head.is_detached
   assert repo_a.handle.active_branch.name == "test_single"
-  assert repo_a.handle.head.commit.hexsha == baseline_commit
+  assert repo_a.handle.head.commit == baseline_commit
 
-  # If commit moves, it'll checkout in detached HEAD state.
-  new_commit = repo_a.handle.commit('HEAD~1').hexsha
+  # If the commit moves, and exists on the default branch (develop) it will go there. Choose a
+  # commit that only exists on develop branch.
+  new_commit = repo_a._verify_tag('8a477c37ae584072dd1c7909c5000f5e2677fec5')
   repo_a.update(new_commit, None)
+  assert repo_a.handle.active_branch.name == "develop"
+  assert repo_a.handle.head.commit == new_commit
+
+  # If the commit does not exist on the default branch, it'll checkout in detached HEAD state.
+  repo_a.update(baseline_commit, None)
   assert repo_a.handle.head.is_detached
-  assert repo_a.handle.head.commit.hexsha == new_commit
+  assert repo_a.handle.head.commit == baseline_commit
 
 
 def test_update_dirty_repo(repo_a):

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,3 +1,14 @@
+# Tests the gordion.Tree interface. A Tree has a gordion.yaml file and recursively manages children.
+# In particular, we are interested in testing the behavior of the "diamond" situation:
+#
+# Repository A lists Repository B and C. B and C both list D.
+#
+#   A
+#  / \
+# B   C
+#  \ /
+#   D
+
 import os
 import gordion
 import pytest


### PR DESCRIPTION
* Get the default branch for a repository by checking the mirror's active branch, which is automatically set to the default remote branch when it is cloned.
* Use the default branch during update if the target branch is not specified or does not contain the commit.
* Rename test_single.py -> test_repository.py and only test the gordion.Repository interface there.
* Rename test_diamond.py -> test_tree.py but add a comment header to discuss the diamond situation of interest.
* Move the gordion cache directory to `~/.local/share/gordion`